### PR TITLE
Wait for the DOM to be ready

### DIFF
--- a/js/questions_and_answers.js
+++ b/js/questions_and_answers.js
@@ -1,4 +1,4 @@
-(function ($) {
+jQuery(function ($) {
 
     var $questions = $('.field-collection-item-field-questions-and-answers > .content > h2');
 
@@ -17,4 +17,4 @@
         })
     });
 
-})(jQuery);
+});


### PR DESCRIPTION
The Cambridge theme puts JavaScript at the bottom of the page so the content is ready when the Feature's JS fires, but if the feature is used with a different theme that puts JS in the `<head>` the content isn't available when the JS fires, leading to nothing happening. This makes sure that it's not immediately invoked.
