### PR TITLE
Add revision ID index

### DIFF
--- a/cambridge_questions_and_answers.features.field_base.inc
+++ b/cambridge_questions_and_answers.features.field_base.inc
@@ -74,7 +74,11 @@ function cambridge_questions_and_answers_field_default_field_bases() {
     'entity_types' => array(),
     'field_name' => 'field_questions_and_answers',
     'foreign keys' => array(),
-    'indexes' => array(),
+    'indexes' => array(
+      'revision_id' => array(
+        0 => 'revision_id',
+      ),
+    ),
     'locked' => 0,
     'module' => 'field_collection',
     'settings' => array(


### PR DESCRIPTION
A revision ID index was added in http://drupalcode.org/project/field_collection.git/commit/0fd332e, this adds it to the feature to prevent it appearing as overridden.
