### PR TITLE
Match Features 2.4 changes

### DIFF
--- a/cambridge_questions_and_answers.features.field_base.inc
+++ b/cambridge_questions_and_answers.features.field_base.inc
@@ -17,14 +17,6 @@ function cambridge_questions_and_answers_field_default_field_bases() {
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_answer',
-    'foreign keys' => array(
-      'format' => array(
-        'columns' => array(
-          'format' => 'format',
-        ),
-        'table' => 'filter_format',
-      ),
-    ),
     'indexes' => array(
       'format' => array(
         0 => 'format',
@@ -44,14 +36,6 @@ function cambridge_questions_and_answers_field_default_field_bases() {
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_question',
-    'foreign keys' => array(
-      'format' => array(
-        'columns' => array(
-          'format' => 'format',
-        ),
-        'table' => 'filter_format',
-      ),
-    ),
     'indexes' => array(
       'format' => array(
         0 => 'format',
@@ -73,7 +57,6 @@ function cambridge_questions_and_answers_field_default_field_bases() {
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_questions_and_answers',
-    'foreign keys' => array(),
     'indexes' => array(
       'revision_id' => array(
         0 => 'revision_id',


### PR DESCRIPTION
Features 2.4 [removed some redundant information](https://www.drupal.org/node/2419479), so to stop it appearing as overridden this matches the change.